### PR TITLE
Add snes9x v1.62.3 support

### DIFF
--- a/SuperMetroid/LiveSplit.SuperMetroid.asl
+++ b/SuperMetroid/LiveSplit.SuperMetroid.asl
@@ -605,7 +605,7 @@ init
     if (memory.ProcessName.ToLower().Contains("snes9x")) {
         // TODO: These should probably be module-relative offsets too. Then
         // some of this codepath can be unified with the RA stuff below.
-        var versions = new Dictionary<int, long>{
+        var legacyVersions = new Dictionary<int, long>{
             { 10330112, 0x789414 },   // snes9x 1.52-rr
             { 7729152, 0x890EE4 },    // snes9x 1.54-rr
             { 5914624, 0x6EFBA4 },    // snes9x 1.53
@@ -632,8 +632,19 @@ init
         };
 
         long pointerAddr;
-        if (versions.TryGetValue(modules.First().ModuleMemorySize, out pointerAddr)) {
+        if (legacyVersions.TryGetValue(modules.First().ModuleMemorySize, out pointerAddr)) {
             memoryOffset = memory.ReadPointer((IntPtr)pointerAddr);
+        }
+        else {
+            // Module-relative addresses
+            var versions = new Dictionary<int, int>{
+                { 10399744, 0x587494 }, // snes9x 1.62.3
+                { 15474688, 0xA32314 }, // snes9x 1.62.3 (x64)
+            };
+            int wramAddr;
+            if (versions.TryGetValue(modules.First().ModuleMemorySize, out wramAddr)) {
+                memoryOffset = modules.First().BaseAddress + wramAddr;
+            }
         }
     } else if (memory.ProcessName.ToLower().Contains("higan") || memory.ProcessName.ToLower().Contains("bsnes") || memory.ProcessName.ToLower().Contains("emuhawk") || memory.ProcessName.ToLower().Contains("lsnes-bsnes")) {
         var versions = new Dictionary<int, long>{

--- a/SuperMetroid/README.md
+++ b/SuperMetroid/README.md
@@ -5,7 +5,7 @@ This script can be used with [LiveSplit](http://livesplit.github.io) for speedru
 ## Supported emulators:
 - higan v102 through v110
 - bsnes v107 through v112, and v115 (not Nightly)
-- Snes9x 1.53 through 1.60 (win32 or win32-x64)
+- Snes9x 1.53 through 1.60, and 1.62.3 (win32 or win32-x64)
 - RetroArch 1.7.5 (x86-64) (with Snes9x or higan cores)
 - BizHawk 2.3 through 2.3.2 (with bsnes core)
 - lsnes rr2-β23 (with bsnes v085 compatibility core)


### PR DESCRIPTION
I was working on another autosplitter and based the method for finding WRAM across different emulators on this one (this was a very helpful reference!). I added support for snes9x v1.62.3 this way. It's keeping the existing pointer list for legacy versions, and adds an additional list of module-relative offsets for the current versions of snes9x. It's perhaps a little ugly, but I hope it helps :)